### PR TITLE
Fix Typo in AcfFieldJSON namespace

### DIFF
--- a/acf-json.php
+++ b/acf-json.php
@@ -24,5 +24,5 @@ add_action('plugins_loaded', function () {
 add_action('init', 'acf_field_type_json', 1);
 
 function acf_field_type_json() {
-	new AcfFieldJson\AcfPluginJson();
+	new AcfFieldTypeJson\AcfPluginJson();
 }


### PR DESCRIPTION
AcfFieldJson was an incorrect Namespace, I've replaced it to the correct one